### PR TITLE
📌 Pin to an LTS release of .NET

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
       matrix:
         cfg: [Release, Debug]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        version: ['5.x']
+        version: ['6.x']
     runs-on: ${{ matrix.os }}
     env:
       DOTNET_NOLOGO: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install Tools
       run: dotnet tool restore
     - name: Check Formatting
-      run: dotnet format --check
+      run: dotnet format --verify-no-changes
     - name: Build Project
       run: >-
         dotnet build --nologo --no-restore

--- a/Atmosphere/Atmosphere.psd1
+++ b/Atmosphere/Atmosphere.psd1
@@ -6,7 +6,7 @@
   Description = 'Cmdlets for working with environment variables and paths'
   ModuleVersion = '0.3.0'
   CompatiblePSEditions = 'Core'
-  PowerShellVersion = '7.1'
+  PowerShellVersion = '7.2'
   RootModule = 'Atmosphere.dll'
 
   CmdletsToExport = @(
@@ -38,13 +38,12 @@
       ReleaseNotes = @'
 # 0.3.0-Alpha
 
-⬆ Upgrade to Powershell 7.1 and .NET 5
+⬆ Upgrade to Powershell 7.2 and .NET 6
 
-This was a long time coming, as 7.1 is the closest thing to a stable release
-for some time now. The primary changes with this release are a bump in
-dependencies and a change in how the project is generated. Having the prior
-0.2.0-Alpha allows us to break free from Powershell 7.0 and still have a
-general 'upgrade' path for users.
+This was a long time coming, as 7.2 is am LTS release now. The primary changes
+with this release are a bump in dependencies and a change in how the project is
+generated. Having the prior 0.2.0-Alpha allows us to break free from Powershell
+7.0 and still have a general 'upgrade' path for users.
 
 🔨 Modify build system to be more streamlined/helpful
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.1.4" Pin="true"/>
+    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.2.1" Pin="true"/>
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="codecov.msbuild" Version="1.13.0" />
     <PackageVersion Include="coverlet.collector" Version="3.1.2" />


### PR DESCRIPTION
This resolves a longstanding issue of PRs failing because of powershell
7.2 upgrades
